### PR TITLE
Change .innerHTML to .innerText to mitigate XSS

### DIFF
--- a/js.js
+++ b/js.js
@@ -11,7 +11,7 @@ async function refresh () {
         let msgP = document.createElement("p");
         let dtP = document.createElement("p");
         msgP.innerText = JSON.stringify(posts[i].msg)
-        dtP.innerHTML = JSON.stringify(posts[i].dt)
+        dtP.innerText = JSON.stringify(posts[i].dt)
         dtP.style.fontSize = "0.5em";
         div.appendChild(msgP);
         div.appendChild(dtP);
@@ -48,7 +48,7 @@ function publishPost() {
     let dtP = document.createElement("p");
     msgP.innerText = '"' + newPost.value + '"';
     newPost.value = "";
-    dtP.innerHTML = '"' + datetime + '"';
+    dtP.innerText = '"' + datetime + '"';
     dtP.style.fontSize = "0.5em";
     div.appendChild(msgP);
     div.appendChild(dtP);


### PR DESCRIPTION
An attacker may gain access to the database and inject malicious scripts into the datetime field, leading to malicious code execution in a users browser. While unlikely, this should still be mitigated by modifying the DOM with innerText rather than innerHTML. Currently, the datetime DOM modification will work exactly the same using innerText as innerHTML, so this change should be compatible with the current commit.